### PR TITLE
fix: avoid focus restore when opening settings and improve accessory …

### DIFF
--- a/clipaste/Managers/ClipboardPanelManager.swift
+++ b/clipaste/Managers/ClipboardPanelManager.swift
@@ -288,12 +288,12 @@ class ClipboardPanelManager {
     }
 
     /// Force-hides the panel regardless of pin state (used by paste/settings/about).
-    func forceHidePanel() {
+    func forceHidePanel(restoringPreviousApp: Bool = true) {
         guard isVisible else { return }
-        executeHide()
+        executeHide(restoringPreviousApp: restoringPreviousApp)
     }
 
-    private func executeHide() {
+    private func executeHide(restoringPreviousApp: Bool = true) {
         guard let panel = panel else { return }
         removeEventMonitor()
         panel.orderOut(nil)
@@ -301,7 +301,7 @@ class ClipboardPanelManager {
         isVisible = false
 
         // 将焦点精准归还给呼出面板前的 App（保证 Cmd+V 粘贴命中目标窗口）
-        if let app = previousActiveApp, !app.isTerminated {
+        if restoringPreviousApp, let app = previousActiveApp, !app.isTerminated {
             app.activate()
         }
         previousActiveApp = nil

--- a/clipaste/Views/ClipboardHeaderView.swift
+++ b/clipaste/Views/ClipboardHeaderView.swift
@@ -686,10 +686,7 @@ struct ClipboardHeaderView: View {
             Divider()
 
             Button("Settings…") {
-                NotificationCenter.default.post(
-                    name: NSNotification.Name("HidePanelForce"),
-                    object: nil
-                )
+                ClipboardPanelManager.shared.forceHidePanel(restoringPreviousApp: false)
                 SettingsWindowCoordinator.open {
                     openSettings()
                 }
@@ -701,10 +698,7 @@ struct ClipboardHeaderView: View {
 
             Button("About Clipaste") {
                 NSApp.orderFrontStandardAboutPanel()
-                NotificationCenter.default.post(
-                    name: NSNotification.Name("HidePanelForce"),
-                    object: nil
-                )
+                ClipboardPanelManager.shared.forceHidePanel(restoringPreviousApp: false)
             }
 
             Button("Send Feedback") {

--- a/clipaste/Views/SettingsWindowCoordinator.swift
+++ b/clipaste/Views/SettingsWindowCoordinator.swift
@@ -68,6 +68,8 @@ enum SettingsWindowCoordinator {
             return
         }
 
+        attachCloseObserver(to: window)
+
         window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
     }
@@ -82,10 +84,9 @@ enum SettingsWindowCoordinator {
             object: window,
             queue: .main
         ) { _ in
-            // 已在主线程，直接同步处理，不需要额外的异步嵌套
             Task { @MainActor in
                 removeCloseObserver(for: window)
-                restoreAccessoryPolicyIfNeeded()
+                scheduleAccessoryPolicyRestoreAfterClose()
             }
         }
     }
@@ -95,6 +96,20 @@ enum SettingsWindowCoordinator {
         let windowID = ObjectIdentifier(window)
         guard let observer = closeObservers.removeValue(forKey: windowID) else { return }
         NotificationCenter.default.removeObserver(observer)
+    }
+
+    @MainActor
+    private static func scheduleAccessoryPolicyRestoreAfterClose() {
+        let delays: [TimeInterval] = [0, 0.05, 0.2]
+
+        for delay in delays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                Task { @MainActor in
+                    guard shouldRestoreAccessoryPolicy else { return }
+                    restoreAccessoryPolicyIfNeeded()
+                }
+            }
+        }
     }
 
     @MainActor


### PR DESCRIPTION
修复在 macos 26.4.1 上从剪切板打开设置页面后 dock 栏图标无法隐藏，效果已在设备上经过验证