### PR TITLE
Skip link metadata fetch when link display mode is plain

### DIFF
--- a/clipaste/ViewModels/ClipboardViewModel+Items.swift
+++ b/clipaste/ViewModels/ClipboardViewModel+Items.swift
@@ -167,6 +167,10 @@ private extension ClipboardViewModel {
     }
 
     func enqueueMissingLinkMetadata(for sourceItems: [ClipboardItem]) {
+        // In plain (Default) mode neither titles nor icons are shown,
+        // so there is no point making background network requests.
+        guard settingsViewModel.linkDisplayMode == .rich else { return }
+
         let candidates = sourceItems
             .lazy
             .filter { $0.isFastLink && ($0.linkTitle == nil || $0.linkIconData == nil) }


### PR DESCRIPTION
In Default (plain) mode, page titles and favicons are never displayed, so the background HTTP requests to fetch them serve no purpose. Guard enqueueMissingLinkMetadata to return early when linkDisplayMode != .rich.